### PR TITLE
AUTO-570 Update tests to get back to 100% coverage

### DIFF
--- a/amazonia/classes/asg.py
+++ b/amazonia/classes/asg.py
@@ -114,7 +114,7 @@ class Asg(SecurityEnabledObject):
             userdata=userdata
         ))
         if userdata is None:
-            self.trop_asg.LaunchConfigurationName.userdata = ''
+            self.lc.UserData = ''
         return title
 
     def create_launch_config(self, title, keypair, image_id, instance_type, iam_instance_profile_arn, userdata):

--- a/amazonia/classes/yaml.py
+++ b/amazonia/classes/yaml.py
@@ -91,7 +91,8 @@ class Yaml(object):
                     self.user_stack_data[unit_type][unit].get(unit_value, self.default_data[unit_value])
                 # Validate for unecrypted aws access ids and aws secret keys
                 if unit_value == 'userdata':
-                    self.detect_unencrypted_access_keys(self.united_data[unit_type][unit]['userdata'])
+                    if self.united_data[unit_type][unit]['userdata'] is not None:
+                        self.detect_unencrypted_access_keys(self.united_data[unit_type][unit]['userdata'])
                 # Validate that minsize is less than maxsize
                 if unit_value == 'minsize':
                     minsize = self.united_data[unit_type][unit][unit_value]

--- a/test/unit_tests/test_asg.py
+++ b/test/unit_tests/test_asg.py
@@ -163,7 +163,7 @@ def test_no_cd_group_and_no_sns():
 @with_setup(setup_resources())
 def test_no_userdata():
     """
-    Tests that a minimum auto scaling value cannot be larger than the maximum that is provided.
+    Tests that an empty userdata is correctly handled
     """
 
     global userdata

--- a/test/unit_tests/test_asg.py
+++ b/test/unit_tests/test_asg.py
@@ -162,6 +162,10 @@ def test_no_cd_group_and_no_sns():
 
 @with_setup(setup_resources())
 def test_no_userdata():
+    """
+    Tests that a minimum auto scaling value cannot be larger than the maximum that is provided.
+    """
+
     global userdata
     userdata = None
 

--- a/test/unit_tests/test_asg.py
+++ b/test/unit_tests/test_asg.py
@@ -1,6 +1,6 @@
 import troposphere.elasticloadbalancing as elb
 from nose.tools import *
-from troposphere import ec2, Ref, Template, Join
+from troposphere import ec2, Ref, Template, Join, Base64
 
 from amazonia.classes.asg import Asg, MalformedSNSError
 
@@ -67,6 +67,7 @@ def test_asg():
     """
     Tests correct structure of autoscaling group objects.
     """
+    global userdata
     asg_titles = ['simple', 'hard', 'harder', 'easy']
 
     for title in asg_titles:
@@ -91,6 +92,7 @@ def test_asg():
         assert_equals(asg.lc.InstanceType, 't2.micro')
         assert_equals(asg.lc.KeyName, 'pipeline')
         assert_equals(asg.lc.IamInstanceProfile, 'arn:aws:iam::12345678987654321:role/InstanceProfileRole')
+        assert_is(type(asg.lc.UserData), Base64)
         [assert_is(type(sg), Ref) for sg in asg.lc.SecurityGroups]
         assert_equals(asg.cd_app.title, title + 'Asg' + 'Cda')
         assert_is(type(asg.cd_app.ApplicationName), Join)
@@ -157,6 +159,15 @@ def test_no_cd_group_and_no_sns():
     )
     assert_is_none(asg.cd_app)
     assert_is_none(asg.cd_deploygroup)
+
+@with_setup(setup_resources())
+def test_no_userdata():
+    global userdata
+    userdata = None
+
+    asg = create_asg('nouserdata')
+
+    assert_equals(asg.lc.UserData, '')
 
 
 def create_asg(title):

--- a/test/unit_tests/test_yaml.py
+++ b/test/unit_tests/test_yaml.py
@@ -183,6 +183,18 @@ def test_insecure_variables_yaml():
                                                   'default_data': default_data,
                                                   'schema': schema})
 
+@with_setup(setup_resources())
+def test_invalid_min_max_asg():
+    """
+    Test the detection of a larger minimum that the provided maximum for an auto scaling unit
+    """
+    global default_data
+    invalid_min_max_stack_data = open_yaml_file('invalid_min_max_asg.yaml')
+
+    assert_raises(ValidationError, Yaml, **{'user_stack_data':invalid_min_max_stack_data,
+                                            'default_data': default_data,
+                                            'schema': schema})
+
 
 def test_detect_unencrypted_access_keys():
     """


### PR DESCRIPTION
**amazonia/classes/asg.py**
- Corrected UserData assignment if empty. (should now assign correctly to the launch config)

**amazonia/classes/yaml.py**
- Checks for unencrypted AWS access keys or secret keys only if the userdata is not empty.

**test/unit_tests/test_asg.py**
- Tests for correct assignment of user data
- Tests for correct handling of an empty user data

**test/unit_tests/test_yaml.py**
- Tests for correct handling of incorrect max/min values (max cannot be less than min)

Build Passing: https://gaautobots.atlassian.net/builds/browse/PIPE-AT79-3