### PR TITLE
Updating DBInstanceIdentifer to use unit title without 'Rds' AUTO-762

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.7] - 23/08/2016
+- Restoring application.yaml
+- Updating DBInstanceIdentifer to use unit title without 'Rds'
+- Adding test for DBInstanceIdentifer in test_database_unit.py
+
 ## [1.2.6] - 23/08/2016
 - Creating DBINstance parameter for database unit
 - Removing Dbname was passing in a RDS snapshot id

--- a/amazonia/application.yaml
+++ b/amazonia/application.yaml
@@ -2,10 +2,4 @@ keypair: 'INSERT_YOUR_KEYPAIR_HERE'
 autoscaling_units:
   -
     unit_title: 'app1'
-    dependencies:
-      - 'db3'
-database_units:
-  -
-    unit_title: 'db3'
-    database_config:
-      db_snapshot_id: 'amazonia-verbose-snapshot'
+

--- a/amazonia/application.yaml
+++ b/amazonia/application.yaml
@@ -2,4 +2,3 @@ keypair: 'INSERT_YOUR_KEYPAIR_HERE'
 autoscaling_units:
   -
     unit_title: 'app1'
-

--- a/amazonia/classes/database_unit.py
+++ b/amazonia/classes/database_unit.py
@@ -34,7 +34,7 @@ class DatabaseUnit(SecurityEnabledObject):
             'DBInstanceClass': database_config.db_instance_type,
             'DBSubnetGroupName': Ref(self.trop_db_subnet_group),
             'DBName': database_config.db_name,
-            'DBInstanceIdentifier': self.title[:-3],
+            'DBInstanceIdentifier': Join('', [Ref('AWS::StackName'), self.title[:-3]]),
             'Engine': database_config.db_engine,
             'Port': self.port,
             'VPCSecurityGroups': [Ref(self.security_group)],

--- a/amazonia/classes/database_unit.py
+++ b/amazonia/classes/database_unit.py
@@ -34,7 +34,7 @@ class DatabaseUnit(SecurityEnabledObject):
             'DBInstanceClass': database_config.db_instance_type,
             'DBSubnetGroupName': Ref(self.trop_db_subnet_group),
             'DBName': database_config.db_name,
-            'DBInstanceIdentifier': Join('', [Ref('AWS::StackName'), self.title]),
+            'DBInstanceIdentifier': self.title,
             'Engine': database_config.db_engine,
             'Port': self.port,
             'VPCSecurityGroups': [Ref(self.security_group)],

--- a/amazonia/classes/database_unit.py
+++ b/amazonia/classes/database_unit.py
@@ -34,7 +34,7 @@ class DatabaseUnit(SecurityEnabledObject):
             'DBInstanceClass': database_config.db_instance_type,
             'DBSubnetGroupName': Ref(self.trop_db_subnet_group),
             'DBName': database_config.db_name,
-            'DBInstanceIdentifier': self.title,
+            'DBInstanceIdentifier': self.title[:-3],
             'Engine': database_config.db_engine,
             'Port': self.port,
             'VPCSecurityGroups': [Ref(self.security_group)],

--- a/test/unit_tests/test_database_unit.py
+++ b/test/unit_tests/test_database_unit.py
@@ -82,6 +82,7 @@ def test_database():
     assert_equals(db.trop_db.BackupRetentionPeriod, '4'),
     assert_equals(db.trop_db.PreferredMaintenanceWindow, 'Mon:01:00-Mon:01:30'),
     assert_equals(db.trop_db.StorageType, 'gp2')
+    assert_equals(db.trop_db.DBInstanceIdentifier, 'MyDb')
 
     assert_raises(InvalidFlowError, db.add_unit_flow, **{'receiver': db})
 
@@ -106,3 +107,4 @@ def test_databse_snapshot():
     assert_equals(len(template.outputs), 1)
     assert_equals(len(template.parameters), 0)
     assert_equals(db.trop_db.AllocatedStorage, 5)
+    assert_equals(db.trop_db.DBInstanceIdentifier, 'MyDb')

--- a/test/unit_tests/test_database_unit.py
+++ b/test/unit_tests/test_database_unit.py
@@ -1,5 +1,5 @@
 from nose.tools import *
-from troposphere import ec2, Ref, Tags, Template
+from troposphere import ec2, Ref, Tags, Template, Join
 from amazonia.classes.database_config import DatabaseConfig
 from amazonia.classes.network_config import NetworkConfig
 from amazonia.classes.database_unit import DatabaseUnit, InvalidFlowError
@@ -82,8 +82,7 @@ def test_database():
     assert_equals(db.trop_db.BackupRetentionPeriod, '4'),
     assert_equals(db.trop_db.PreferredMaintenanceWindow, 'Mon:01:00-Mon:01:30'),
     assert_equals(db.trop_db.StorageType, 'gp2')
-    assert_equals(db.trop_db.DBInstanceIdentifier, 'MyDb')
-
+    assert_equals(type(db.trop_db.DBInstanceIdentifier), Join)
     assert_raises(InvalidFlowError, db.add_unit_flow, **{'receiver': db})
 
 
@@ -107,4 +106,4 @@ def test_databse_snapshot():
     assert_equals(len(template.outputs), 1)
     assert_equals(len(template.parameters), 0)
     assert_equals(db.trop_db.AllocatedStorage, 5)
-    assert_equals(db.trop_db.DBInstanceIdentifier, 'MyDb')
+    assert_equals(type(db.trop_db.DBInstanceIdentifier), Join)


### PR DESCRIPTION
## [1.2.7] - 23/08/2016
- Restoring application.yaml
- Updating DBInstanceIdentifer to use unit title without 'Rds'
- Adding test for DBInstanceIdentifer in test_database_unit.py

Passing Build - https://gaautobots.atlassian.net/builds/browse/AM-AUT58/latest