### PR TITLE
Added UpdatePolicy to Autoscaling groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.3.1] - 25/08/2016
+## [1.3.1] - 26/08/2016
 - Added UpdatePolicy to Autoscaling Groups to ensure changes to autoscaling groups or launch config will correctly update instances.
 - Corrected web_app.yaml to the latest format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.1] - 25/08/2016
+- Added UpdatePolicy to Autoscaling Groups to ensure changes to autoscaling groups or launch config will correctly update instances.
+- Corrected web_app.yaml to the latest format
+
 ## [1.3.0] - 24/08/2016
 - Introducing SSLCertificateId for ELBs
 - Changing path2ping to elb_health_check and making it an explicit health check e.g. /index.html --> HTTP:80/index.html. Updates to app and default yamls required 

--- a/amazonia/classes/asg.py
+++ b/amazonia/classes/asg.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python3
 
 from troposphere import Base64, codedeploy, Ref, Join, Output
-from troposphere.policies import (
-    UpdatePolicy, AutoScalingRollingUpdate, AutoScalingReplacingUpdate
-)
+from troposphere.policies import UpdatePolicy, AutoScalingRollingUpdate
 from troposphere.autoscaling import AutoScalingGroup, LaunchConfiguration, Tag, NotificationConfigurations
 
 from amazonia.classes.security_enabled_object import SecurityEnabledObject

--- a/amazonia/classes/asg.py
+++ b/amazonia/classes/asg.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python3
 
-from troposphere import Base64, codedeploy, Ref, Join, Output, ec2
+from troposphere import Base64, codedeploy, Ref, Join, Output
+from troposphere.policies import (
+    UpdatePolicy, AutoScalingRollingUpdate, AutoScalingReplacingUpdate
+)
 from troposphere.autoscaling import AutoScalingGroup, LaunchConfiguration, Tag, NotificationConfigurations
 
 from amazonia.classes.security_enabled_object import SecurityEnabledObject
@@ -60,7 +63,12 @@ class Asg(SecurityEnabledObject):
             LoadBalancerNames=[Ref(load_balancer) for load_balancer in load_balancers],
             HealthCheckGracePeriod=asg_config.health_check_grace_period,
             HealthCheckType=asg_config.health_check_type,
-            Tags=[Tag('Name', Join('', [Ref('AWS::StackName'), '-', title]), True)])
+            Tags=[Tag('Name', Join('', [Ref('AWS::StackName'), '-', title]), True)]),
+        )
+
+        self.trop_asg.resource['UpdatePolicy'] = UpdatePolicy(
+            AutoScalingRollingUpdate=AutoScalingRollingUpdate(
+            )
         )
 
         if asg_config.sns_topic_arn is not None:

--- a/test/unit_tests/test_asg.py
+++ b/test/unit_tests/test_asg.py
@@ -1,6 +1,7 @@
 import troposphere.elasticloadbalancing as elb
 from nose.tools import *
 from troposphere import ec2, Ref, Template, Join, Base64
+from troposphere.policies import AutoScalingRollingUpdate
 
 from amazonia.classes.asg import Asg, MalformedSNSError
 from amazonia.classes.asg_config import AsgConfig
@@ -124,6 +125,7 @@ def test_asg():
         assert_is(type(asg.cd_deploygroup.DeploymentGroupName), Join)
         [assert_is(type(cdasg), Ref) for cdasg in asg.cd_deploygroup.AutoScalingGroups]
         assert_equals(asg.cd_deploygroup.ServiceRoleArn, 'arn:aws:iam::12345678987654321:role/CodeDeployServiceRole')
+        assert_is(type(asg.trop_asg.resource['UpdatePolicy'].AutoScalingRollingUpdate), AutoScalingRollingUpdate)
 
 
 @with_setup(setup_resources)

--- a/web/web_app.yaml
+++ b/web/web_app.yaml
@@ -6,32 +6,36 @@ stack_hosted_zone_name: 'gadevs.ga.'
 autoscaling_units:
   -
     unit_title: 'api'
-    image_id: 'ami-dc361ebf'
-    protocols:
-      - 'HTTP'
-    instance_port:
-      - '80'
-    loadbalancer_port:
-      - '80'
-    elb_health_check: 'HTTP:80/amazonia/web/index.html'
-    userdata: |
-      #cloud-config
-      repo_update: true
-      repo_upgrade: all
-      packages:
-       - httpd
-       - git
-       - python34-pip
-      runcmd:
-       - cd /var/www/html
-       - git clone https://github.com/GeoscienceAustralia/amazonia.git
-       - cd amazonia
-       - pip-3.4 install -e . --user
-       - export FLASK_APP=/var/www/html/amazonia/web/api.py
-       - echo "<VirtualHost *:80>" >> /etc/httpd/conf/httpd.conf
-       - echo "    ProxyPass /yaml http://localhost:5000/yaml" >> /etc/httpd/conf/httpd.conf
-       - echo "    ProxyPassReverse /yaml http://localhost:5000/yaml" >> /etc/httpd/conf/httpd.conf
-       - echo "</VirtualHost>" >> /etc/httpd/conf/httpd.conf
-       - service httpd reload
-       - service httpd start
-       - python3 -m flask run --host=0.0.0.0
+    asg_config:
+      image_id: 'ami-dc361ebf'
+      userdata: |
+        #cloud-config
+        repo_update: true
+        repo_upgrade: all
+        packages:
+         - httpd
+         - git
+         - python34-pip
+        runcmd:
+         - cd /var/www/html
+         - git clone https://github.com/GeoscienceAustralia/amazonia.git
+         - cd amazonia
+         - pip-3.4 install -e . --user
+         - export FLASK_APP=/var/www/html/amazonia/web/api.py
+         - echo "<VirtualHost *:80>" >> /etc/httpd/conf/httpd.conf
+         - echo "    ProxyPass /yaml http://localhost:5000/yaml" >> /etc/httpd/conf/httpd.conf
+         - echo "    ProxyPassReverse /yaml http://localhost:5000/yaml" >> /etc/httpd/conf/httpd.conf
+         - echo "</VirtualHost>" >> /etc/httpd/conf/httpd.conf
+         - service httpd reload
+         - service httpd start
+         - python3 -m flask run --host=0.0.0.0
+    elb_config:
+      elb_health_check: 'HTTP:80/amazonia/web/index.html'
+      instance_protocol:
+        - 'HTTP'
+      instance_port:
+        - '80'
+      loadbalancer_protocol:
+        - 'HTTP'
+      loadbalancer_port:
+        - '80'


### PR DESCRIPTION
### amazonia/classes/asg.py
* Added Import UpdatePolicy, AutoScalingRollingUpdate from the troposphere.policies library
* Added an empty UpdatePolicy for AutoScallingRollingUpdate to autoscaling groups by default. This should avoid blowing away autoscaling groups on an UPDATE_STACK unless completely unavoidable.

### test/unit_tests/test_asg.py
* Updated tests to cover the above changes to asg.py

### web/web_app.yaml
* Updated web_app.yaml to work with the latest format in case a redeploy of the web_app is needed in future.

## Passing build: https://gaautobots.atlassian.net/builds/browse/AM-AUT60/latest