### PR TITLE
AUTO-827 - Added output for api deployment endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.3.10] - 12/09/2016
 - Refactor Cloudfront distributions
+- Added an Output for the endpoint of each deployment that is created for api gateway units. Storing these in an 'endpoints' list.
 
 ## [1.3.9] - 8/09/2016
 - Add extra configuration for ELBs - healthy/unhealthy thresholds, interval, timeout

--- a/amazonia/classes/api_gateway_unit.py
+++ b/amazonia/classes/api_gateway_unit.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from troposphere import Ref, Join, GetAtt
+from troposphere import Ref, Join, GetAtt, Output
 from troposphere.apigateway import RestApi, Resource, MethodResponse, IntegrationResponse, Integration, Method
 from troposphere.apigateway import Deployment
 
@@ -34,6 +34,7 @@ class ApiGatewayUnit(object):
         self.network_config = network_config
         self.method_config = method_config
         self.deployment_config = deployment_config
+        self.endpoints = []
 
         self.api = self.template.add_resource(RestApi(
                                                       '{0}API'.format(self.title),
@@ -166,6 +167,23 @@ class ApiGatewayUnit(object):
 
         self.deployments.append(deployment)
         self.template.add_resource(deployment)
+
+        value = Join('', ['https://',
+                          Ref(self.api),
+                          '.execute-api.',
+                          Ref("AWS::Region"),
+                          '.amazonaws.com/',
+                          deployment.StageName
+                          ]
+                     )
+
+        self.endpoints.append(value)
+
+        self.template.add_output(Output(
+            deployment.title,
+            Description='URL of API deployment: {0}'.format(deployment.title),
+            Value=value
+        ))
 
     def add_unit_flow(self, other_unit):
         """

--- a/test/unit_tests/test_api_gateway.py
+++ b/test/unit_tests/test_api_gateway.py
@@ -185,6 +185,10 @@ def test_creation_of_deployment():
     assert_equals(type(api.deployments[0].RestApiId), Ref)
     assert_equals(api.deployments[0].StageName, deployment.stagename)
 
+    assert_equals(type(api.endpoints[0]), Join)
+    assert_equals(len(api.endpoints), 1)
+    assert_equals(len(api.endpoints), len(api.deployments))
+
 
 @with_setup(setup_resources())
 def create_request_config():


### PR DESCRIPTION
Api GW uses cloudfront for it's addresses and that seems to break if route 53 is put in front of it.

Instead we are now creating a list of deployment endpoints for an api gateway unit, and an output for each deployment endpoint.

We can then use the endpoints in cloudfront to create origins and put route53 in front of that instead.

Passing: https://gaautobots.atlassian.net/builds/browse/AM-AUT86/latest