### PR TITLE
Implement Sticky Cookies for ELBs AUTO-825

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.10] - 16/09/2016
+- Implement Sticky Cookies for ELBs
+
 ## [1.3.9] - 14/09/2016
 - Add extra configuration for ELBs - healthy/unhealthy thresholds, interval, timeout
 - Refactor Cloudfront distributions

--- a/amazonia/classes/elb.py
+++ b/amazonia/classes/elb.py
@@ -22,7 +22,6 @@ class Elb(SecurityEnabledObject):
         self.network_config = network_config
         super(Elb, self).__init__(vpc=network_config.vpc, title=self.title, template=template)
         elb_listeners = elb_config.elb_listeners_config
-        print('elb_listeners={0}'.format(elb_listeners))
         subnets = network_config.public_subnets if elb_config.public_unit is True else network_config.private_subnets
 
         # Create ELB

--- a/amazonia/classes/elb.py
+++ b/amazonia/classes/elb.py
@@ -47,6 +47,19 @@ class Elb(SecurityEnabledObject):
                              Tags=Tags(Name=self.title),
                              DependsOn=network_config.get_depends_on()))
 
+        if elb_config.sticky_app_cookies:
+            sticky_app_cookies = []
+
+            for number, sticky_app_cookie in enumerate(elb_config.sticky_app_cookies):
+                policy_name = self.title + 'AppCookiePolicy' + str(number)
+
+                sticky_app_cookies.append(elb.AppCookieStickinessPolicy(
+                    CookieName=sticky_app_cookie,
+                    PolicyName=policy_name
+                ))
+
+            self.trop_elb.AppCookieStickinessPolicy = sticky_app_cookies
+
         for listener in self.trop_elb.Listeners:
             if elb_config.ssl_certificate_id and listener.Protocol == 'HTTPS':
                 listener.SSLCertificateId = elb_config.ssl_certificate_id

--- a/amazonia/classes/elb_config.py
+++ b/amazonia/classes/elb_config.py
@@ -1,7 +1,7 @@
 class ElbConfig(object):
     def __init__(self, instance_protocol, instance_port, loadbalancer_protocol, loadbalancer_port, elb_health_check,
                  public_unit, elb_log_bucket, ssl_certificate_id, healthy_threshold, unhealthy_threshold,
-                 interval, timeout):
+                 interval, timeout, sticky_app_cookies):
         """
         Simple config class to contain elb related parameters
         :param instance_protocol: instance_protocol for ELB to communicate with webserver
@@ -15,6 +15,7 @@ class ElbConfig(object):
         :param unhealthy_threshold: Number of consecutive health check successes before marking as Unhealthy
         :param interval: Interval between health checks
         :param timeout: Amount of time during which no response means a failed health check
+        :param sticky_app_cookies: List of application cookies used for stickiness
 
         """
         self.instance_protocol = instance_protocol
@@ -29,3 +30,4 @@ class ElbConfig(object):
         self.unhealthy_threshold = unhealthy_threshold
         self.interval = interval
         self.timeout = timeout
+        self.sticky_app_cookies = sticky_app_cookies if sticky_app_cookies else []

--- a/amazonia/classes/yaml_fields.py
+++ b/amazonia/classes/yaml_fields.py
@@ -40,6 +40,7 @@ class YamlFields(object):
                            'unhealthy_threshold',
                            'interval',
                            'timeout',
+                           'sticky_app_cookies'
                            ]
 
     # asg_config field list

--- a/amazonia/defaults.yaml
+++ b/amazonia/defaults.yaml
@@ -85,6 +85,7 @@ elb_config:
   unhealthy_threshold: 2
   interval: 300
   timeout: 30
+  sticky_app_cookies:
 
 # Block device configs
 block_devices_config:

--- a/amazonia/schemas/cerberus_schema.yaml
+++ b/amazonia/schemas/cerberus_schema.yaml
@@ -67,6 +67,11 @@ elb_config: &elb_config
     timeout:
       nullable: True
       type: 'number'
+    sticky_app_cookies:
+      type: 'list'
+      nullable: True
+      schema:
+        type: 'string'
 
 simple_scaling_policy_config: &simple_scaling_policy_config
   type: 'dict'

--- a/test/sys_tests/test_sys_autoscaling_unit.py
+++ b/test/sys_tests/test_sys_autoscaling_unit.py
@@ -99,7 +99,8 @@ runcmd:
         healthy_threshold=10,
         unhealthy_threshold=2,
         interval=300,
-        timeout=30
+        timeout=30,
+        sticky_app_cookies=['JSESSION', 'SESSIONTOKEN']
     )
 
     block_devices_config = [BlockDevicesConfig(device_name='/dev/xvda',

--- a/test/sys_tests/test_sys_elb.py
+++ b/test/sys_tests/test_sys_elb.py
@@ -104,7 +104,8 @@ def main():
         healthy_threshold=10,
         unhealthy_threshold=2,
         interval=300,
-        timeout=30
+        timeout=30,
+        sticky_app_cookies=['JSESSION','SESSIONTOKEN']
     )
     elb_config2 = ElbConfig(
         elb_listeners_config=elb_listeners_config,
@@ -115,7 +116,8 @@ def main():
         healthy_threshold=10,
         unhealthy_threshold=2,
         interval=300,
-        timeout=30
+        timeout=30,
+        sticky_app_cookies=['JSESSION','SESSIONTOKEN']
     )
     elb_config3 = ElbConfig(
         elb_listeners_config=elb_listeners_config,
@@ -126,7 +128,8 @@ def main():
         healthy_threshold=10,
         unhealthy_threshold=2,
         interval=300,
-        timeout=30
+        timeout=30,
+        sticky_app_cookies=['JSESSION','SESSIONTOKEN']
     )
 
     Elb(title='MyUnit1',

--- a/test/sys_tests/test_sys_stack.py
+++ b/test/sys_tests/test_sys_stack.py
@@ -89,7 +89,8 @@ runcmd:
                  healthy_threshold=10,
                  unhealthy_threshold=2,
                  interval=300,
-                 timeout=30
+                 timeout=30,
+                 sticky_app_cookies=['JSESSION', 'SESSIONTOKEN']
              ),
              'blue_asg_config': AsgConfig(
                  minsize=1,
@@ -148,7 +149,8 @@ runcmd:
                                 healthy_threshold=10,
                                 unhealthy_threshold=2,
                                 interval=300,
-                                timeout=30
+                                timeout=30,
+                                sticky_app_cookies=['JSESSION', 'SESSIONTOKEN']
                             ),
                             'dependencies': ['app2', 'db1']},
                            {'unit_title': 'app2',
@@ -178,7 +180,8 @@ runcmd:
                                 healthy_threshold=10,
                                 unhealthy_threshold=2,
                                 interval=300,
-                                timeout=30
+                                timeout=30,
+                                sticky_app_cookies=['JSESSION', 'SESSIONTOKEN']
                             ),
                             'dependencies': []}
                            ],

--- a/test/sys_tests/test_sys_stack.py
+++ b/test/sys_tests/test_sys_stack.py
@@ -58,10 +58,10 @@ runcmd:
                                                ebs_encrypted=False,
                                                ebs_snapshot_id=None,
                                                virtual_name=False)]
-    elb_listeners_config = ElbListenersConfig(loadbalancer_protocol='HTTP',
+    elb_listeners_config = [ElbListenersConfig(loadbalancer_protocol='HTTP',
                                               instance_protocol='HTTP',
                                               instance_port='80',
-                                              loadbalancer_port='80')
+                                              loadbalancer_port='80')]
 
     stack = Stack(
         code_deploy_service_role='arn:aws:iam::12345678987654321:role/CodeDeployServiceRole',

--- a/test/sys_tests/test_sys_zd_autoscaling_unit.py
+++ b/test/sys_tests/test_sys_zd_autoscaling_unit.py
@@ -92,6 +92,7 @@ runcmd:
     unhealthy_threshold = 2
     interval = 300
     timeout = 30
+    sticky_app_cookies = ['JSESSION', 'SESSIONTOKEN']
     minsize = 1
     maxsize = 1
     health_check_grace_period = 300
@@ -118,7 +119,8 @@ runcmd:
                            healthy_threshold=healthy_threshold,
                            unhealthy_threshold=unhealthy_threshold,
                            interval=interval,
-                           timeout=timeout
+                           timeout=timeout,
+                           sticky_app_cookies=sticky_app_cookies
                            )
     blue_asg_config = AsgConfig(sns_topic_arn=None,
                                 sns_notification_types=None,

--- a/test/unit_tests/test_autoscaling_unit.py
+++ b/test/unit_tests/test_autoscaling_unit.py
@@ -110,7 +110,8 @@ runcmd:
         healthy_threshold=10,
         unhealthy_threshold=2,
         interval=300,
-        timeout=30
+        timeout=30,
+        sticky_app_cookies=['JSESSION', 'SESSIONTOKEN']
     )
 
 

--- a/test/unit_tests/test_stack.py
+++ b/test/unit_tests/test_stack.py
@@ -31,7 +31,7 @@ def setup_resources():
         elb_health_check, home_cidrs, nat_image_id, jump_image_id, health_check_grace_period, health_check_type, \
         unit_image_id, db_instance_type, db_engine, db_port, db_hdd_size, owner_emails, nat_alerting, \
         db_backup_window, db_backup_retention, db_maintenance_window, db_storage_type, block_devices_config, \
-        healthy_threshold, unhealthy_threshold, interval, timeout
+        healthy_threshold, unhealthy_threshold, interval, timeout, sticky_app_cookies
     userdata = """#cloud-config
 repo_update: true
 repo_upgrade: all
@@ -62,6 +62,7 @@ runcmd:
     unhealthy_threshold = 2
     interval = 300
     timeout = 30
+    sticky_app_cookies = ['JSESSION','SESSIONTOKEN']
     public_cidr = {'name': 'PublicIp', 'cidr': '0.0.0.0/0'}
     health_check_grace_period = 300
     health_check_type = 'ELB'
@@ -147,7 +148,7 @@ def test_highly_available_nat_stack():
         elb_health_check, home_cidrs, nat_image_id, jump_image_id, health_check_grace_period, health_check_type, \
         unit_image_id, db_instance_type, db_engine, db_port, owner_emails, nat_alerting, db_backup_window, \
         db_backup_retention, db_maintenance_window, db_storage_type, block_devices_config, healthy_threshold, \
-        unhealthy_threshold, interval, timeout
+        unhealthy_threshold, interval, timeout, sticky_app_cookies
 
     stack = Stack(
         code_deploy_service_role=code_deploy_service_role,
@@ -264,7 +265,8 @@ def test_duplicate_unit_names():
                                    healthy_threshold=healthy_threshold,
                                    unhealthy_threshold=unhealthy_threshold,
                                    interval=interval,
-                                   timeout=timeout
+                                   timeout=timeout,
+                                   sticky_app_cookies=sticky_app_cookies
                                ),
                                'dependencies': [],
                                },
@@ -281,7 +283,8 @@ def test_duplicate_unit_names():
                                    healthy_threshold=healthy_threshold,
                                    unhealthy_threshold=unhealthy_threshold,
                                    interval=interval,
-                                   timeout=timeout
+                                   timeout=timeout,
+                                   sticky_app_cookies=sticky_app_cookies
                                ),
                                'asg_config': AsgConfig(
                                    minsize=minsize,
@@ -317,7 +320,7 @@ def create_stack():
         elb_health_check, home_cidrs, nat_image_id, jump_image_id, health_check_grace_period, health_check_type, \
         unit_image_id, db_instance_type, db_engine, db_port, owner_emails, nat_alerting, db_backup_window, \
         db_backup_retention, db_maintenance_window, db_storage_type, block_devices_config, healthy_threshold, \
-        unhealthy_threshold, interval, timeout
+        unhealthy_threshold, interval, timeout, sticky_app_cookies
 
     stack = Stack(
         code_deploy_service_role=code_deploy_service_role,
@@ -349,7 +352,8 @@ def create_stack():
                                    healthy_threshold=healthy_threshold,
                                    unhealthy_threshold=unhealthy_threshold,
                                    interval=interval,
-                                   timeout=timeout
+                                   timeout=timeout,
+                                   sticky_app_cookies=sticky_app_cookies
                                ),
                                'blue_asg_config': AsgConfig(
                                    minsize=minsize,
@@ -394,7 +398,8 @@ def create_stack():
                                 healthy_threshold=healthy_threshold,
                                 unhealthy_threshold=unhealthy_threshold,
                                 interval=interval,
-                                timeout=timeout
+                                timeout=timeout,
+                                sticky_app_cookies=sticky_app_cookies
                             ),
                             'asg_config': AsgConfig(
                                 minsize=minsize,
@@ -425,7 +430,8 @@ def create_stack():
                                 healthy_threshold=healthy_threshold,
                                 unhealthy_threshold=unhealthy_threshold,
                                 interval=interval,
-                                timeout=timeout
+                                timeout=timeout,
+                                sticky_app_cookies=sticky_app_cookies
                             ),
                             'asg_config': AsgConfig(
                                 minsize=minsize,

--- a/test/unit_tests/test_zd_autoscaling_unit.py
+++ b/test/unit_tests/test_zd_autoscaling_unit.py
@@ -90,7 +90,8 @@ runcmd:
                            healthy_threshold=10,
                            unhealthy_threshold=2,
                            interval=300,
-                           timeout=30)
+                           timeout=30,
+                           sticky_app_cookies=['JSESSION', 'SESSIONTOKEN'])
     common_asg_config = AsgConfig(
         minsize=1,
         maxsize=1,


### PR DESCRIPTION
Add functionality for Sentinel Sticky Cookies requirement. This is related to authentication for Sentinel Secure, which is tracked by a JSESSIONID cookie.

Passing build: https://gaautobots.atlassian.net/builds/browse/AM-AST71/latest
Passing unit tests: https://gaautobots.atlassian.net/builds/browse/AM-AUT88/latest