### PR TITLE
Add support for ACM certificates to Cloudfront distributions AUTO-841

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.13] - 21/09/2016
+- Add support for ACM certificates to Cloudfront distributions
+
 ## [1.3.12] - 20/09/2016
 - Adding sticky app cookie to test_yaml_complete_valid (mmm, sticky app cookie)
 

--- a/amazonia/classes/cf_distribution_unit.py
+++ b/amazonia/classes/cf_distribution_unit.py
@@ -43,6 +43,12 @@ class CFDistributionUnit(object):
             PriceClass=cf_distribution_config.price_class
         )
 
+        if cf_distribution_config.acm_cert_arn:
+            self.cf_dist.ViewerCertificate = cloudfront.ViewerCertificate(
+                AcmCertificateArn=cf_distribution_config.acm_cert_arn,
+                SslSupportMethod='sni-only'
+            )
+
         self.cf_dist = template.add_resource(cloudfront.Distribution(
             self.title,
             DistributionConfig=self.cf_dist

--- a/amazonia/defaults.yaml
+++ b/amazonia/defaults.yaml
@@ -149,7 +149,7 @@ cf_distribution_config:
   enabled: True
   price_class: 'PriceClass_All'
   error_page_path: '404.html'
-  acm_cert_arn: ''
+  acm_cert_arn: 
   minimum_protocol_version: 'TLSv1'
   ssl_support_method: 'sni-only'
 

--- a/amazonia/schemas/cerberus_schema.yaml
+++ b/amazonia/schemas/cerberus_schema.yaml
@@ -253,6 +253,7 @@ cf_distribution_config: &cf_distribution_config
     acm_cert_arn:
       type: 'string'
       nullable: True
+      regex: 'arn:aws:acm:us-east-1:\w+:certificate\/.*'
     minimum_protocol_version:
       type: 'string'
       nullable: True

--- a/amazonia/schemas/cerberus_schema.yaml
+++ b/amazonia/schemas/cerberus_schema.yaml
@@ -253,7 +253,6 @@ cf_distribution_config: &cf_distribution_config
     acm_cert_arn:
       type: 'string'
       nullable: True
-      regex: 'arn:aws:acm:us-east-1:\w+:certificate\/.*'
     minimum_protocol_version:
       type: 'string'
       nullable: True

--- a/test/sys_tests/test_sys_cfdistribution.py
+++ b/test/sys_tests/test_sys_cfdistribution.py
@@ -87,7 +87,7 @@ def main():
         enabled=True,
         price_class='PriceClass_All',
         error_page_path='index.html',
-        acm_cert_arn='',
+        acm_cert_arn='arn:aws:cloudfront::123456789012:distribution/ABCD1234EFGH56',
         minimum_protocol_version='TLSv1',
         ssl_support_method='sni-only'
     )

--- a/test/sys_tests/test_sys_cfdistribution.py
+++ b/test/sys_tests/test_sys_cfdistribution.py
@@ -87,7 +87,7 @@ def main():
         enabled=True,
         price_class='PriceClass_All',
         error_page_path='index.html',
-        acm_cert_arn='arn:aws:cloudfront::123456789012:distribution/ABCD1234EFGH56',
+        acm_cert_arn='arn:aws:acm:us-east-1:123456789012:certificate/12345678-abcd-efgh-1234-abcd12345678',
         minimum_protocol_version='TLSv1',
         ssl_support_method='sni-only'
     )

--- a/test/unit_tests/test_cf_distribution.py
+++ b/test/unit_tests/test_cf_distribution.py
@@ -276,7 +276,7 @@ def test_cf_distribution_config():
     enabled = True
     price_class = 'PriceClass_All'
     error_page_path = 'index.html'
-    acm_cert_arn = 'arn.acm.certificate'
+    acm_cert_arn = 'arn:aws:cloudfront::123456789012:distribution/ABCD1234EFGH56'
     minimum_protocol_version = 'TLSv1'
     ssl_support_method = 'sni-only'
 
@@ -298,8 +298,5 @@ def test_cf_distribution_config():
     assert_equal(default_root_object, helper_cf_dist.default_root_object)
     assert_equal(enabled, helper_cf_dist.enabled)
     assert_equal(price_class, helper_cf_dist.price_class)
+    assert_equal(acm_cert_arn, helper_cf_dist.acm_cert_arn)
     assert_equal(error_page_path, helper_cf_dist.error_page_path)
-#
-# def test_multiple_default_cache_behaviors():
-#
-#     assert_raises(CloudfrontConfigError, )

--- a/test/unit_tests/test_cf_distribution.py
+++ b/test/unit_tests/test_cf_distribution.py
@@ -276,7 +276,7 @@ def test_cf_distribution_config():
     enabled = True
     price_class = 'PriceClass_All'
     error_page_path = 'index.html'
-    acm_cert_arn = 'arn:aws:cloudfront::123456789012:distribution/ABCD1234EFGH56'
+    acm_cert_arn = 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-abcd-efgh-1234-abcd12345678'
     minimum_protocol_version = 'TLSv1'
     ssl_support_method = 'sni-only'
 


### PR DESCRIPTION
Passing build: https://gaautobots.atlassian.net/builds/browse/AM-AST75-RSTWVAY/latest
Passing build: https://gaautobots.atlassian.net/builds/browse/AM-AUT92/latest