### PR TITLE
Dev mettjo auto 850 add ec2 scheduling

### DIFF
--- a/amazonia/classes/amz_autoscaling.py
+++ b/amazonia/classes/amz_autoscaling.py
@@ -26,15 +26,14 @@ class Autoscaling(object):
         self.instance_ports = [listener.instance_port for listener in elb_config.elb_listeners_config]
         self.dependencies = dependencies if dependencies else []
 
+        asg_config.ec2_scheduled_shutdown = ec2_scheduled_shutdown
+
         self.elb = Elb(
             title=title,
             template=self.template,
             network_config=network_config,
             elb_config=elb_config
         )
-
-        if ec2_scheduled_shutdown:
-            asg_config.ec2_scheduled_shutdown = True
 
         self.asg = Asg(
             title=title,
@@ -80,7 +79,7 @@ class AutoscalingLeaf(Autoscaling, Leaf):
         self.tree_config.private_hosted_zone_id = ImportValue(self.tree_name + '-PrivateHostedZoneId')
         self.tree_config.private_hosted_zone_domain = ImportValue(self.tree_name + '-PrivateHostedZoneDomain')
         super(AutoscalingLeaf, self).__init__(leaf_title, template, self.tree_config, elb_config, asg_config,
-                                              dependencies)
+                                              dependencies, asg_config.ec2_scheduled_shutdown)
 
         self.template.add_output(Output(
             'elbSecurityGroup',
@@ -107,7 +106,7 @@ class AutoscalingLeaf(Autoscaling, Leaf):
 
 class AutoscalingUnit(Autoscaling):
     def __init__(self, unit_title, template, dependencies, stack_config, elb_config, asg_config,
-                 ec2_scheduled_shutdown=False):
+                 ec2_scheduled_shutdown):
         """
         Create an integrated Amazonia unit, with associated Amazonia ELB and ASG
         :param unit_title: Title of the autoscaling application  prefixedx with Stack name e.g 'MyStackWebApp1',

--- a/amazonia/classes/amz_autoscaling.py
+++ b/amazonia/classes/amz_autoscaling.py
@@ -9,7 +9,7 @@ from troposphere import Output, GetAtt, ImportValue, Export
 
 
 class Autoscaling(object):
-    def __init__(self, title, template, network_config, elb_config, asg_config, dependencies):
+    def __init__(self, title, template, network_config, elb_config, asg_config, dependencies, ec2_scheduled_shutdown):
         """
         Create Amazonia Autoscaling resources, an ELB, an autosclaing group and other associated resources
         :param title: title of the amazonia obect and associated resources to be used in cloud formation
@@ -18,6 +18,7 @@ class Autoscaling(object):
         :param elb_config: config related to Elastic Load Balancer
         :param asg_config: config related to AutoScaling Group
         :param dependencies: List of resources to create network flow to
+        :param ec2_scheduled_shutdown: True/False for whether to schedule shutdown for EC2 instances outside work hours
         """
         self.title = title
         self.template = template
@@ -31,6 +32,10 @@ class Autoscaling(object):
             network_config=network_config,
             elb_config=elb_config
         )
+
+        if ec2_scheduled_shutdown:
+            asg_config.ec2_scheduled_shutdown = True
+
         self.asg = Asg(
             title=title,
             template=self.template,
@@ -101,7 +106,8 @@ class AutoscalingLeaf(Autoscaling, Leaf):
 
 
 class AutoscalingUnit(Autoscaling):
-    def __init__(self, unit_title, template, dependencies, stack_config, elb_config, asg_config):
+    def __init__(self, unit_title, template, dependencies, stack_config, elb_config, asg_config,
+                 ec2_scheduled_shutdown=False):
         """
         Create an integrated Amazonia unit, with associated Amazonia ELB and ASG
         :param unit_title: Title of the autoscaling application  prefixedx with Stack name e.g 'MyStackWebApp1',
@@ -111,9 +117,10 @@ class AutoscalingUnit(Autoscaling):
         :param stack_config: object containing stack network configuration
         :param elb_config: config related to Elastic Load Balancer
         :param asg_config: config related to AutoScaling Group
+        :param ec2_scheduled_shutdown: True/False for whether to schedule shutdown for EC2 instances outside work hours
         """
         super(AutoscalingUnit, self).__init__(unit_title, template, stack_config, elb_config, asg_config,
-                                              dependencies)
+                                              dependencies, ec2_scheduled_shutdown)
         for dependency in self.dependencies:
             portless_dependency_name = dependency.split(':')[0]
             dependency_port = dependency.split(':')[1]

--- a/amazonia/classes/asg_config.py
+++ b/amazonia/classes/asg_config.py
@@ -14,7 +14,8 @@ class InvalidAsgConfigError(Exception):
 class AsgConfig(object):
     def __init__(self, health_check_grace_period,
                  health_check_type, minsize, maxsize, image_id, instance_type, userdata,
-                 iam_instance_profile_arn, block_devices_config, simple_scaling_policy_config):
+                 iam_instance_profile_arn, block_devices_config, simple_scaling_policy_config,
+                 ec2_scheduled_shutdown):
         """
         Simple config class to contain autoscaling group related parameters
         :param minsize: minimum size of autoscaling group
@@ -27,6 +28,7 @@ class AsgConfig(object):
         :param health_check_type: The type of health check. currently 'ELB' or 'EC2' are the only valid types.
         :param block_devices_config: List containing block device mappings
         :param simple_scaling_policy_config: List containing scaling policies
+        :param ec2_scheduled_shutdown: True/False for whether to schedule shutdown for EC2 instances outside work hours
         """
         self.health_check_grace_period = health_check_grace_period
         self.health_check_type = health_check_type
@@ -38,6 +40,7 @@ class AsgConfig(object):
         self.iam_instance_profile_arn = iam_instance_profile_arn
         self.block_devices_config = block_devices_config
         self.simple_scaling_policy_config = simple_scaling_policy_config
+        self.ec2_scheduled_shutdown = ec2_scheduled_shutdown
 
         # check for insecure variables
         if self.userdata is not None:

--- a/amazonia/classes/network.py
+++ b/amazonia/classes/network.py
@@ -13,7 +13,7 @@ from troposphere.ec2 import EIP, NatGateway
 class Network(object):
     def __init__(self, keypair, availability_zones, vpc_cidr, home_cidrs, public_cidr, jump_image_id,
                  jump_instance_type, nat_image_id, nat_instance_type, public_hosted_zone_name, private_hosted_zone_name,
-                 iam_instance_profile_arn, owner_emails, nat_highly_available):
+                 iam_instance_profile_arn, owner_emails, nat_highly_available, ec2_scheduled_shutdown):
         """
         Create a vpc, nat, jumphost, internet gateway, public/private route tables, public/private subnets
          and collection of Amazonia units
@@ -36,6 +36,7 @@ class Network(object):
         :param iam_instance_profile_arn: the ARN for an IAM instance profile that enables cloudtrail access for logging
         :param owner_emails: a list of emails for owners of this stack. Used for alerting.
         :param nat_highly_available: True/False for whether or not to use a series of NAT gateways or a single NAT
+        :param ec2_scheduled_shutdown: True/False for whether to schedule shutdown for EC2 instances outside work hours
         """
 
         super(Network, self).__init__()
@@ -54,6 +55,7 @@ class Network(object):
         self.owner_emails = owner_emails if owner_emails else []
         self.nat_highly_available = nat_highly_available
         self.iam_instance_profile_arn = iam_instance_profile_arn
+        self.ec2_scheduled_shutdown = ec2_scheduled_shutdown
 
         # initialize object references
         self.template = Template()
@@ -143,7 +145,8 @@ class Network(object):
             iam_instance_profile_arn=self.iam_instance_profile_arn,
             is_nat=False,
             sns_topic=self.sns_topic,
-            availability_zone=availability_zones[0]
+            availability_zone=availability_zones[0],
+            ec2_scheduled_shutdown=self.ec2_scheduled_shutdown
         )
 
         # Add Jumpbox and NAT and associated security group ingress and egress rules
@@ -190,7 +193,8 @@ class Network(object):
                 iam_instance_profile_arn=self.iam_instance_profile_arn,
                 public_hosted_zone_name=None,
                 sns_topic=self.sns_topic,
-                availability_zone=availability_zones[0]
+                availability_zone=availability_zones[0],
+                ec2_scheduled_shutdown=self.ec2_scheduled_shutdown
             )
 
             self.nat = SingleInstance(

--- a/amazonia/classes/single_instance_config.py
+++ b/amazonia/classes/single_instance_config.py
@@ -3,7 +3,8 @@
 
 class SingleInstanceConfig(object):
     def __init__(self, vpc, sns_topic, keypair, si_image_id, si_instance_type, subnet, availability_zone,
-                 instance_dependencies, iam_instance_profile_arn, public_hosted_zone_name, is_nat):
+                 instance_dependencies, iam_instance_profile_arn, public_hosted_zone_name, is_nat,
+                 ec2_scheduled_shutdown):
         """
         Simple config class to contain networking related parameters
         :param vpc: Troposphere vpc object, required for SecurityEnabledObject class
@@ -17,6 +18,7 @@ class SingleInstanceConfig(object):
         :param instance_dependencies: a list of dependencies to wait for before creating the single instance.
         :param iam_instance_profile_arn: the ARN for an IAM profile that enables cloudwatch logging.
         :param availability_zone: availabiity zone to create single instance in
+        :param ec2_scheduled_shutdown: True/False for whether to schedule shutdown for EC2 instances outside work hours
         """
         self.vpc = vpc
         self.sns_topic = sns_topic
@@ -29,3 +31,4 @@ class SingleInstanceConfig(object):
         self.public_hosted_zone_name = public_hosted_zone_name
         self.is_nat = is_nat
         self.availability_zone = availability_zone
+        self.ec2_scheduled_shutdown = ec2_scheduled_shutdown

--- a/amazonia/classes/stack.py
+++ b/amazonia/classes/stack.py
@@ -65,9 +65,8 @@ class Stack(Network):
         self.units = {}
         self.network_config = None
 
-        if ec2_scheduled_shutdown:
-            for autoscaling_unit in self.autoscaling_units:
-                autoscaling_unit['ec2_scheduled_shutdown'] = True
+        for autoscaling_unit in self.autoscaling_units:
+            autoscaling_unit['ec2_scheduled_shutdown'] = ec2_scheduled_shutdown
 
         self.network_config = NetworkConfig(vpc=self.vpc,
                                             public_subnets=[Ref(subnet) for subnet in self.public_subnets],

--- a/amazonia/classes/stack.py
+++ b/amazonia/classes/stack.py
@@ -16,7 +16,7 @@ class Stack(Network):
                  public_cidr, jump_image_id, jump_instance_type, nat_image_id, nat_instance_type, zd_autoscaling_units,
                  autoscaling_units, database_units, cf_distribution_units, public_hosted_zone_name,
                  private_hosted_zone_name, iam_instance_profile_arn, owner_emails, api_gateway_units, lambda_units,
-                 nat_highly_available):
+                 nat_highly_available, ec2_scheduled_shutdown):
         """
         Create a vpc, nat, jumphost, internet gateway, public/private route tables, public/private subnets
          and collection of Amazonia units
@@ -47,12 +47,14 @@ class Stack(Network):
         :param iam_instance_profile_arn: the ARN for an IAM instance profile that enables cloudtrail access for logging
         :param owner_emails: a list of emails for owners of this stack. Used for alerting.
         :param nat_highly_available: True/False for whether or not to use a series of NAT gateways or a single NAT
+        :param ec2_scheduled_shutdown: True/False for whether to schedule shutdown for EC2 instances outside work hours
         """
 
         super(Stack, self).__init__(
             keypair, availability_zones, vpc_cidr, home_cidrs, public_cidr, jump_image_id,
             jump_instance_type, nat_image_id, nat_instance_type, public_hosted_zone_name,
-            private_hosted_zone_name, iam_instance_profile_arn, owner_emails, nat_highly_available)
+            private_hosted_zone_name, iam_instance_profile_arn, owner_emails, nat_highly_available,
+            ec2_scheduled_shutdown)
         self.code_deploy_service_role = code_deploy_service_role
         self.autoscaling_units = autoscaling_units if autoscaling_units else []
         self.database_units = database_units if database_units else []
@@ -62,6 +64,10 @@ class Stack(Network):
         self.lambda_units = lambda_units if lambda_units else []
         self.units = {}
         self.network_config = None
+
+        if ec2_scheduled_shutdown:
+            for autoscaling_unit in self.autoscaling_units:
+                autoscaling_unit['ec2_scheduled_shutdown'] = True
 
         self.network_config = NetworkConfig(vpc=self.vpc,
                                             public_subnets=[Ref(subnet) for subnet in self.public_subnets],

--- a/amazonia/classes/tree.py
+++ b/amazonia/classes/tree.py
@@ -7,7 +7,7 @@ from troposphere import Ref, Output, Export
 class Tree(Network):
     def __init__(self, tree_name, keypair, availability_zones, vpc_cidr, home_cidrs, public_cidr, jump_image_id,
                  jump_instance_type, nat_image_id, nat_instance_type, public_hosted_zone_name, private_hosted_zone_name,
-                 iam_instance_profile_arn, owner_emails, nat_highly_available):
+                 iam_instance_profile_arn, owner_emails, nat_highly_available, ec2_scheduled_shutdown):
         """
         Create a vpc, nat, jumphost, internet gateway, public/private route tables, public/private subnets
          and collection of Amazonia units
@@ -31,13 +31,14 @@ class Tree(Network):
         :param iam_instance_profile_arn: the ARN for an IAM instance profile that enables cloudtrail access for logging
         :param owner_emails: a list of emails for owners of this stack. Used for alerting.
         :param nat_highly_available: True/False for whether or not to use a series of NAT gateways or a single NAT
+        :param ec2_scheduled_shutdown: True/False for whether to schedule shutdown for EC2 instances outside work hours
         """
         self.tree_name = tree_name
 
         super(Tree, self).__init__(keypair, availability_zones, vpc_cidr, home_cidrs, public_cidr, jump_image_id,
                                    jump_instance_type, nat_image_id, nat_instance_type, public_hosted_zone_name,
                                    private_hosted_zone_name,
-                                   iam_instance_profile_arn, owner_emails, nat_highly_available)
+                                   iam_instance_profile_arn, owner_emails, nat_highly_available, ec2_scheduled_shutdown)
 
         self.template.add_output(Output(
             'vpc',

--- a/amazonia/classes/yaml_fields.py
+++ b/amazonia/classes/yaml_fields.py
@@ -57,7 +57,8 @@ class YamlFields(object):
                            'userdata',
                            'iam_instance_profile_arn',
                            'block_devices_config',
-                           'simple_scaling_policy_config'
+                           'simple_scaling_policy_config',
+                           'ec2_scheduled_shutdown'
                            ]
 
     # simple_scaling_policy field list

--- a/amazonia/classes/yaml_fields.py
+++ b/amazonia/classes/yaml_fields.py
@@ -180,7 +180,8 @@ class YamlFields(object):
         'lambda_units',
         'database_units',
         'iam_instance_profile_arn',
-        'owner_emails'
+        'owner_emails',
+        'ec2_scheduled_shutdown'
     ]
 
     # autoscaling unit parameter field list

--- a/amazonia/defaults.yaml
+++ b/amazonia/defaults.yaml
@@ -121,6 +121,7 @@ asg_config: &asg_config
   health_check_type: 'ELB'
   block_devices_config:
   simple_scaling_policy_config:
+  ec2_scheduled_shutdown:
   userdata: |
     #cloud-config
     repo_update: true

--- a/amazonia/defaults.yaml
+++ b/amazonia/defaults.yaml
@@ -36,6 +36,7 @@ iam_instance_profile_arn:
 zd_autoscaling_units:
 autoscaling_units:
 database_units:
+ec2_scheduled_shutdown:
 
 # Common unit default values
 unit_title: 'defaulttitle'

--- a/amazonia/schemas/cerberus_schema.yaml
+++ b/amazonia/schemas/cerberus_schema.yaml
@@ -168,6 +168,9 @@ asg_config: &asg_config
       type: 'list'
       nullable: True
       schema: *simple_scaling_policy_config # any scaling policies based upon cpu usage
+    ec2_scheduled_shutdown:
+      type: 'boolean'
+      nullable: True
 
 blue_asg_config: *asg_config #nested dictionary containing blue asg specific configuration
 green_asg_config: *asg_config #nested dictionary containing blue asg specific configuration

--- a/amazonia/schemas/cerberus_schema.yaml
+++ b/amazonia/schemas/cerberus_schema.yaml
@@ -443,6 +443,10 @@ availability_zones: # A list of strings, specifying each availability zone to us
   schema:
     type: 'string'
     empty: False
+ec2_scheduled_shutdown: # Boolean to specify whether to schedule shutdown for ec2 instances outside work hours
+  type: 'boolean'
+  nullable: True
+
 vpc_cidr: # A cidr block to delegate to your VPC.
   type: 'dict'
   empty: False

--- a/test/sys_tests/network_setup.py
+++ b/test/sys_tests/network_setup.py
@@ -17,7 +17,8 @@ def get_network_config():
                       private_hosted_zone_name='private.lan.',
                       iam_instance_profile_arn='arn:aws:iam::123456789:instance-profile/am-instance-profile',
                       owner_emails=[],
-                      nat_highly_available=False)
+                      nat_highly_available=False,
+                      ec2_scheduled_shutdown=False)
 
     service_role_arn = 'arn:aws:iam::123456789:role/CodeDeployServiceRole'
 

--- a/test/unit_tests/network_setup.py
+++ b/test/unit_tests/network_setup.py
@@ -17,7 +17,8 @@ def get_network_config():
                       private_hosted_zone_name='private.lan.',
                       iam_instance_profile_arn='arn:aws:iam::123456789:instance-profile/iam-instance-profile',
                       owner_emails=[],
-                      nat_highly_available=False)
+                      nat_highly_available=False,
+                      ec2_scheduled_shutdown=None)
 
     cd_service_role_arn = 'arn:aws:iam::123456789:role/CodeDeployServiceRole'
 

--- a/test/unit_tests/test_amz_zd_autoscaling.py
+++ b/test/unit_tests/test_amz_zd_autoscaling.py
@@ -7,7 +7,7 @@ from nose.tools import *
 from troposphere import Ref
 
 template = elb_config = network_config = common_asg_config = block_devices_config = tree_name = availability_zones = \
-    cd_service_role_arn = public_cidr = public_hosted_zone_name = keypair = None
+    cd_service_role_arn = public_cidr = public_hosted_zone_name = keypair = ec2_scheduled_shutdown = None
 
 
 def setup_resources():
@@ -70,7 +70,8 @@ runcmd:
         userdata=userdata,
         iam_instance_profile_arn=None,
         block_devices_config=block_devices_config,
-        simple_scaling_policy_config=None
+        simple_scaling_policy_config=None,
+        ec2_scheduled_shutdown=ec2_scheduled_shutdown
     )
 
 

--- a/test/unit_tests/test_asg.py
+++ b/test/unit_tests/test_asg.py
@@ -80,7 +80,8 @@ runcmd:
         maxsize=1,
         minsize=1,
         block_devices_config=block_devices_config,
-        simple_scaling_policy_config=simple_scaling_policy_config
+        simple_scaling_policy_config=simple_scaling_policy_config,
+        ec2_scheduled_shutdown=None
     )
 
     load_balancer = elb.LoadBalancer('testElb',

--- a/test/unit_tests/test_single_instance.py
+++ b/test/unit_tests/test_single_instance.py
@@ -69,11 +69,24 @@ def test_nat_single_instance():
     assert_equals(si.sns_topic.alarms[0].Dimensions[0].Name, 'InstanceId')
 
 
-def create_si(title, is_nat=False):
+def test_ec2_scheduler_tags_created():
+    """Test whether EC2 scheduler tags are added to single instance"""
+    title_with_schedule = 'siSchedule'
+    si_schedule = create_si(title_with_schedule, ec2_schedule=True)
+    assert_in('1900;0900;utc;sun,mon,tue,wed,thu', [x['Value'] for x in si_schedule.single.properties['Tags'].tags])
+
+    # ensure tags aren't added for instances that aren't scheduled
+    title = 'si'
+    si = create_si(title)
+    assert_not_in('1900;0900;utc;sun,mon,tue,wed,thu', [x['Value'] for x in si.single.properties['Tags'].tags])
+
+
+def create_si(title, is_nat=False, ec2_schedule=None):
     """
     Helper function to create Single instance Troposhpere object to interate through.
     :param title: name of instance
     :param is_nat: is the instance a nat
+    :param ec2_schedule: optional flag to set scheduler tag on instance
     :return: Troposphere object for single instance, security group and output
     """
     vpc = 'vpc-12345'
@@ -96,7 +109,8 @@ def create_si(title, is_nat=False):
         is_nat=is_nat,
         iam_instance_profile_arn='my/instance-profile',
         sns_topic=sns_topic,
-        availability_zone='ap-southeast-2a'
+        availability_zone='ap-southeast-2a',
+        ec2_scheduled_shutdown=ec2_schedule
     )
     si = SingleInstance(title=title,
                         template=template,

--- a/test/unit_tests/test_stack.py
+++ b/test/unit_tests/test_stack.py
@@ -209,6 +209,7 @@ def test_duplicate_unit_names():
         'iam_instance_profile_arn': None,
         'owner_emails': owner_emails,
         'nat_highly_available': False,
+        'ec2_scheduled_shutdown': False,
         'autoscaling_units': [{'unit_title': 'app1',
                                'asg_config': AsgConfig(
                                    minsize=minsize,
@@ -220,7 +221,8 @@ def test_duplicate_unit_names():
                                    userdata=userdata,
                                    iam_instance_profile_arn=None,
                                    block_devices_config=block_devices_config,
-                                   simple_scaling_policy_config=None
+                                   simple_scaling_policy_config=None,
+                                   ec2_scheduled_shutdown=None
                                ),
                                'elb_config': ElbConfig(
                                    elb_listeners_config=elb_listeners_config,
@@ -257,7 +259,8 @@ def test_duplicate_unit_names():
                                    userdata=userdata,
                                    iam_instance_profile_arn=None,
                                    block_devices_config=None,
-                                   simple_scaling_policy_config=None
+                                   simple_scaling_policy_config=None,
+                                   ec2_scheduled_shutdown=None
                                ),
                                'dependencies': [],
                                }],
@@ -297,6 +300,7 @@ def create_stack(nat_highly_available=False):
         iam_instance_profile_arn=None,
         owner_emails=owner_emails,
         nat_highly_available=nat_highly_available,
+        ec2_scheduled_shutdown=False,
         zd_autoscaling_units=[{'unit_title': 'zdapp1',
                                'elb_config': ElbConfig(
                                    elb_listeners_config=elb_listeners_config,
@@ -319,7 +323,8 @@ def create_stack(nat_highly_available=False):
                                    userdata=userdata,
                                    iam_instance_profile_arn=None,
                                    block_devices_config=block_devices_config,
-                                   simple_scaling_policy_config=None
+                                   simple_scaling_policy_config=None,
+                                   ec2_scheduled_shutdown=None
                                ),
                                'green_asg_config': AsgConfig(
                                    minsize=minsize,
@@ -331,7 +336,8 @@ def create_stack(nat_highly_available=False):
                                    userdata=userdata,
                                    iam_instance_profile_arn=None,
                                    block_devices_config=block_devices_config,
-                                   simple_scaling_policy_config=None
+                                   simple_scaling_policy_config=None,
+                                   ec2_scheduled_shutdown=None
                                ),
                                'dependencies': ['app2:5432', 'db1:80'],
                                }],
@@ -357,7 +363,8 @@ def create_stack(nat_highly_available=False):
                                 userdata=userdata,
                                 iam_instance_profile_arn=None,
                                 block_devices_config=block_devices_config,
-                                simple_scaling_policy_config=None
+                                simple_scaling_policy_config=None,
+                                ec2_scheduled_shutdown=None
                             ),
                             'dependencies': ['app2:80', 'db1:5432'],
                             },
@@ -383,7 +390,8 @@ def create_stack(nat_highly_available=False):
                                 userdata=userdata,
                                 iam_instance_profile_arn=None,
                                 block_devices_config=block_devices_config,
-                                simple_scaling_policy_config=None
+                                simple_scaling_policy_config=None,
+                                ec2_scheduled_shutdown=None
                             ),
                             'dependencies': []
                             }],

--- a/test/unit_tests/test_tree.py
+++ b/test/unit_tests/test_tree.py
@@ -3,7 +3,8 @@ from amazonia.classes.util import get_cf_friendly_name
 from nose.tools import *
 from troposphere import Tags, Ref
 
-keypair = instance_type = vpc_cidr = public_cidr = nat_image_id = jump_image_id = owner_emails = None
+keypair = instance_type = vpc_cidr = public_cidr = nat_image_id = jump_image_id = owner_emails = \
+    ec2_scheduled_shutdown = None
 availability_zones = []
 home_cidrs = []
 
@@ -126,4 +127,5 @@ def create_tree(nat_highly_available=False):
         iam_instance_profile_arn=None,
         owner_emails=owner_emails,
         nat_highly_available=nat_highly_available,
+        ec2_scheduled_shutdown=ec2_scheduled_shutdown
     )


### PR DESCRIPTION
Added EC2 scheduling in order to turn off EC2 instances after work hours, through `ec2_scheduled_shutdown` boolean flag to the Stack YAML.

passing tests: https://gaautobots.atlassian.net/builds/browse/AM-AST81-4
passing tests: https://gaautobots.atlassian.net/builds/browse/AM-AUT102-3

1. Adds EC2 Tag onto the NAT and Jump boxes, which will get picked up by [EC2 Scheduler Stack](http://docs.aws.amazon.com/solutions/latest/ec2-scheduler/deployment.html):
`{'Key': 'scheduler:ec2-startstop', 'Value': '1900;0900;utc;sun,mon,tue,wed,thu'}`.
The format for EC2 Scheduler tags is: `'<start time>;<stop time>;utc;<active days>'`.

2.  Creates ScheduledActions for autoscaling group. One to turn scale down instances (`min=0, max=0`), and another to scale it back up.

The `ec2_scheduled_shutdown` flag gets passed from `Stack` down to `Network`->`Single_Instance_Config`->`Single_Instance`  and `AutoscalingUnit`->`Autoscaling`.